### PR TITLE
Refactor ``args_handling`` functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  skip: [pylint]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -46,3 +49,11 @@ repos:
     hooks:
       - id: bandit
         args: [-c, pyproject.toml]
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-ci:
-  skip: [pylint]
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
@@ -49,11 +46,3 @@ repos:
     hooks:
       - id: bandit
         args: [-c, pyproject.toml]
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: pylint
-        language: system
-        types: [python]
-        require_serial: true

--- a/auto_file_sorter/configs_handling.py
+++ b/auto_file_sorter/configs_handling.py
@@ -1,7 +1,15 @@
 """Module responsible for handling the JSON configs."""
 from __future__ import annotations
 
-__all__: list[str] = ["read_from_configs", "write_to_configs"]
+__all__: list[str] = [
+    "read_from_configs",
+    "write_to_configs",
+    "get_selected_configs",
+    "add_new_config_to_configs",
+    "load_json_file_into_configs",
+    "remove_configs",
+    "get_extension_paths_from_configs",
+]
 
 import json
 import logging
@@ -11,7 +19,10 @@ from auto_file_sorter.constants import (
     CONFIG_LOG_LEVEL,
     DEFAULT_CONFIGS_LOCATION,
     EXIT_FAILURE,
+    EXIT_SUCCESS,
+    FILE_EXTENSION_PATTERN,
 )
+from auto_file_sorter.utils import resolved_path_from_str
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -103,3 +114,197 @@ def write_to_configs(
         new_configs,
         configs,
     )
+
+
+def get_selected_configs(
+    get_configs: list[str],
+    configs: dict[str, str],
+) -> dict[str, Path]:
+    """Get the selected configs from the configs and store them in a ``dict``."""
+    selected_configs: dict[str, Path] = {}
+
+    for config in get_configs:
+        extension: str = config.replace(" ", "").lower()
+
+        if FILE_EXTENSION_PATTERN.fullmatch(extension) is None:
+            configs_handling_logger.warning(
+                "Ignoring invalid extension '%s'",
+                extension,
+            )
+            continue
+
+        if extension not in configs:
+            configs_handling_logger.warning(
+                "Ignoring '%s', because it is not in the configs",
+                extension,
+            )
+            continue
+
+        try:
+            selected_configs[extension] = resolved_path_from_str(configs[extension])
+        except KeyError:  # pragma: no cover
+            configs_handling_logger.warning(
+                "Unable to get the respetive path "
+                "of one of the given extensions '%s'",
+                extension,
+            )
+            continue
+
+    if not selected_configs:
+        configs_handling_logger.critical("No valid extensions selected")
+        configs_handling_logger.debug(
+            "repr(selected_configs)=%s",
+            repr(selected_configs),
+        )
+        raise SystemExit(EXIT_FAILURE)
+    return selected_configs
+
+
+def add_new_config_to_configs(new_config: list[str], configs: dict[str, str]) -> int:
+    """Add new config to the configs JSON file."""
+    configs_handling_logger.debug("new_config=%s", repr(new_config))
+
+    new_extension, new_path = (
+        new_config[0].lower().replace(" ", ""),
+        new_config[1].strip(),
+    )
+    configs_handling_logger.debug(
+        "Normalized '%s' to '%s'",
+        new_config[0],
+        new_extension,
+    )
+    configs_handling_logger.debug(
+        "Normalized '%s' to '%s'",
+        new_config[1],
+        new_path,
+    )
+
+    if not new_extension or not new_path:
+        configs_handling_logger.critical(
+            "Either an empty extension '%s' or an empty path '%s' was specified to add, "
+            "which is invalid",
+            new_extension,
+            new_path,
+        )
+        return EXIT_FAILURE
+
+    if FILE_EXTENSION_PATTERN.fullmatch(new_extension) is None:
+        configs_handling_logger.critical(
+            "Given extension '%s' is invalid",
+            new_extension,
+        )
+        return EXIT_FAILURE
+
+    configs_handling_logger.debug("Got '%s': '%s'", new_extension, new_path)
+
+    configs[new_extension] = new_path
+    configs_handling_logger.log(
+        CONFIG_LOG_LEVEL,
+        "Updated '%s': '%s'",
+        new_extension,
+        new_path,
+    )
+    return EXIT_SUCCESS
+
+
+def load_json_file_into_configs(json_file: Path, configs: dict[str, str]) -> int:
+    """Load JSON file into configs."""
+    configs_handling_logger.debug(
+        "json_file='%s'",
+        repr(json_file),
+    )
+
+    if json_file.suffix.lower() != ".json":
+        configs_handling_logger.critical(
+            "Configs can only be read from json files",
+        )
+        return EXIT_FAILURE
+
+    configs_handling_logger.debug("Reading from '%s'", json_file)
+    try:
+        new_configs_from_json: dict[str, str] = json.loads(
+            json_file.read_text(encoding="utf-8"),
+        )
+    except FileNotFoundError:
+        configs_handling_logger.critical(
+            "Unable to find '%s'",
+            json_file,
+        )
+        return EXIT_FAILURE
+    except PermissionError:
+        configs_handling_logger.critical(
+            "Permission denied to open and read from '%s'",
+            json_file,
+        )
+        return EXIT_FAILURE
+    except OSError:
+        configs_handling_logger.critical(
+            "Operating system-related error occurred while opening and reading from '%s'",
+            json_file,
+        )
+        return EXIT_FAILURE
+    except json.JSONDecodeError:
+        configs_handling_logger.critical(
+            "Given JSON file is not correctly formatted: '%s'",
+            json_file,
+        )
+        return EXIT_FAILURE
+    configs_handling_logger.debug("Read from '%s'", json_file)
+
+    configs.update(new_configs_from_json)
+    configs_handling_logger.log(
+        CONFIG_LOG_LEVEL,
+        "Loaded '%s' into configs",
+        json_file,
+    )
+    return EXIT_SUCCESS
+
+
+def remove_configs(configs_to_be_removed: list[str], configs: dict[str, str]) -> int:
+    """Remove configs from the configs."""
+    configs_handling_logger.debug(
+        "configs_to_be_removed=%s",
+        repr(configs_to_be_removed),
+    )
+
+    for config in configs_to_be_removed:
+        extension: str = config.replace(" ", "").lower()
+        configs_handling_logger.debug("Stripped '%s' to '%s'", config, extension)
+
+        if FILE_EXTENSION_PATTERN.fullmatch(extension) is None:
+            configs_handling_logger.warning(
+                "Skipping invalid extension: '%s'",
+                extension,
+            )
+            continue
+
+        configs_handling_logger.debug("Normalized '%s' to '%s'", config, extension)
+
+        configs_handling_logger.debug("Removing '%s'", extension)
+        try:
+            del configs[extension]
+        except KeyError:
+            configs_handling_logger.warning(
+                "Ignoring '%s', because it is not in the configs",
+                extension,
+            )
+            continue
+        configs_handling_logger.log(
+            CONFIG_LOG_LEVEL,
+            "Removed '%s'",
+            extension,
+        )
+    return EXIT_SUCCESS
+
+
+def get_extension_paths_from_configs(
+    configs: dict[str, str],
+) -> dict[str, Path]:
+    """Get the extension and their respective path from the configs."""
+    configs_handling_logger.debug("Resolving extension paths from %s", configs)
+    extension_paths: dict[str, Path] = {
+        extension: resolved_path_from_str(path_as_str)
+        for extension, path_as_str in configs.items()
+    }
+    configs_handling_logger.info("Got extension paths")
+    return extension_paths

--- a/auto_file_sorter/main.py
+++ b/auto_file_sorter/main.py
@@ -14,7 +14,6 @@ from auto_file_sorter.args_handling import (
     handle_read_args,
     handle_track_args,
     handle_write_args,
-    resolved_path_from_str,
 )
 from auto_file_sorter.constants import (
     CONFIG_LOG_LEVEL,
@@ -26,6 +25,7 @@ from auto_file_sorter.constants import (
     STREAM_HANDLER_FORMATTER,
     VERBOSE_OUTPUT_LEVELS,
 )
+from auto_file_sorter.utils import resolved_path_from_str
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/auto_file_sorter/utils.py
+++ b/auto_file_sorter/utils.py
@@ -1,0 +1,11 @@
+"""Module containing useful utilities."""
+from __future__ import annotations
+
+__all__: list[str] = ["resolved_path_from_str"]
+
+from pathlib import Path
+
+
+def resolved_path_from_str(path_as_str: str) -> Path:
+    """Return the absolute path given a string of a path."""
+    return Path(path_as_str.strip()).resolve()

--- a/tests/args_handling_test.py
+++ b/tests/args_handling_test.py
@@ -590,8 +590,9 @@ def test_handle_read_args_all_configs_posix(
         configs_location=test_configs_file,
         get_configs=None,
     )
-    exit_code: int = handle_read_args(args)
-    assert exit_code == 0
+
+    with pytest.raises(SystemExit):
+        handle_read_args(args)
 
     assert capsys.readouterr().out == ".txt: /path/to/txt\n.pdf: /path/to/pdf\n"
 
@@ -666,8 +667,9 @@ def test_handle_read_args_selected_configs_invalid_extensions(
         configs_location=test_configs_file,
         get_configs=["abc"],
     )
-    exit_code: int = handle_read_args(args)
-    assert exit_code == 1
+
+    with pytest.raises(SystemExit):
+        handle_read_args(args)
 
     assert (
         "auto_file_sorter.args_handling",
@@ -691,8 +693,9 @@ def test_handle_read_args_selected_extension_not_in_configs(
         configs_location=test_configs_file,
         get_configs=[".odt"],
     )
-    exit_code: int = handle_read_args(args)
-    assert exit_code == 1
+
+    with pytest.raises(SystemExit):
+        handle_read_args(args)
 
     assert (
         "auto_file_sorter.args_handling",

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -10,7 +10,6 @@ import pytest
 
 # pylint: disable=C0116, W0611
 from auto_file_sorter import __version__
-from auto_file_sorter.args_handling import resolved_path_from_str
 from auto_file_sorter.constants import (
     CONFIG_LOG_LEVEL,
     DEFAULT_CONFIGS_LOCATION,
@@ -22,6 +21,7 @@ from auto_file_sorter.main import (
     _parse_args,
     _setup_logging,
 )
+from auto_file_sorter.utils import resolved_path_from_str
 
 # valid_json_data and test_configs are indirectly used by test_configs_as_str, do not remove!
 from tests.fixtures import (

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,63 @@
+"""Tests for ``auto_file_sorter.utils``."""
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+
+import pytest
+
+from auto_file_sorter.utils import resolved_path_from_str
+
+# pylint: disable=C0116
+
+
+@pytest.mark.skipif(
+    platform.system() != "Windows",
+    reason="Test behavior on Windows-systems",
+)
+@pytest.mark.parametrize(
+    ("path_as_str", "expected_path"),
+    (
+        pytest.param(
+            "/path/to/some/file.txt",
+            Path("C:/path/to/some/file.txt"),
+            id="regular_str",
+        ),
+        pytest.param(
+            "  /path/to/some/file.txt  ",
+            Path("C:/path/to/some/file.txt"),
+            id="trailing_whitespaces_str",
+        ),
+    ),
+)
+def test_resolved_path_from_str_windows(
+    path_as_str: str,
+    expected_path: Path,
+) -> None:  # pragma: win32 cover
+    assert resolved_path_from_str(path_as_str) == expected_path
+
+
+@pytest.mark.skipif(
+    platform.system() != "Linux" and platform.system() != "Darwin",
+    reason="Test behavior on Posix systems",
+)
+@pytest.mark.parametrize(
+    ("path_as_str", "expected_path"),
+    (
+        pytest.param(
+            "/path/to/some/file.txt",
+            Path("/path/to/some/file.txt"),
+            id="regular_str",
+        ),
+        pytest.param(
+            "  /path/to/some/file.txt  ",
+            Path("/path/to/some/file.txt"),
+            id="trailing_whitespaces_str",
+        ),
+    ),
+)
+def test_resolved_path_from_str_posix(
+    path_as_str: str,
+    expected_path: Path,
+) -> None:  # pragma: posix cover
+    assert resolved_path_from_str(path_as_str) == expected_path


### PR DESCRIPTION
Restructure the implementation of several functions in ``args_handling.py`` by extracting them into separate functions now residing in ``configs_handling.py``. The helper function ``resolved_path_from_str`` was also moved into a new module ``utils.py``. Imports, tests and references were adjusted accordingly.